### PR TITLE
fix: P1 correctness bugs — logger category, sun boundary, scheduler fallback, HS colour mode

### DIFF
--- a/HueShift2/HueShift2/Control/AdaptiveLightColourCalculator.cs
+++ b/HueShift2/HueShift2/Control/AdaptiveLightColourCalculator.cs
@@ -65,7 +65,7 @@ namespace HueShift2.Control
                 }
                 return 1.0;
             }
-            if ((currentTime < events.Sunrise && currentTime > currentTime.Date) || currentTime > events.Sunset) return -1.0;
+            if (currentTime < events.Sunrise || currentTime > events.Sunset) return -1.0;
             return 0.0;
         }
 

--- a/HueShift2/HueShift2/Control/AdaptiveLightColourCalculator.cs
+++ b/HueShift2/HueShift2/Control/AdaptiveLightColourCalculator.cs
@@ -14,10 +14,10 @@ namespace HueShift2.Control
 {
     public class AdaptiveLightColourCalculator : ILightColourCalculator
     {
-        private ILogger<LightManager> logger;
+        private ILogger<AdaptiveLightColourCalculator> logger;
         private IOptionsMonitor<HueShiftOptions> appOptionsDelegate;
 
-        public AdaptiveLightColourCalculator(ILogger<LightManager> logger, IOptionsMonitor<HueShiftOptions> appOptionsDelegate)
+        public AdaptiveLightColourCalculator(ILogger<AdaptiveLightColourCalculator> logger, IOptionsMonitor<HueShiftOptions> appOptionsDelegate)
         {
             this.logger = logger;
             this.appOptionsDelegate = appOptionsDelegate;
@@ -63,9 +63,10 @@ namespace HueShift2.Control
                     var scalingFactor = 1.0 - Math.Pow(((currentTime.TimeOfDay - events.SolarNoon.TimeOfDay) / (events.SolarNoon.TimeOfDay - events.Sunset.TimeOfDay)), 2.0);
                     return 1.0 * scalingFactor;
                 }
+                return 1.0;
             }
             if ((currentTime < events.Sunrise && currentTime > currentTime.Date) || currentTime > events.Sunset) return -1.0;
-            throw new InvalidOperationException();
+            return 0.0;
         }
 
         public AppLightState SetBrightnessAndColour(LightCalculationParameters lightCalculationParameters, DateTime currentTime, bool isSleep)

--- a/HueShift2/HueShift2/Control/LightControlPair.cs
+++ b/HueShift2/HueShift2/Control/LightControlPair.cs
@@ -155,20 +155,13 @@ namespace HueShift2.Control
                 this.ExpectedLight.Colour.ColourCoordinates = command.ColorCoordinates;
                 return;
             }
-            else if (command.ColorTemperature != null)
+            if (command.ColorTemperature != null)
             {
                 this.ExpectedLight.Colour.Mode = ColourMode.CT;
                 this.ExpectedLight.Colour.ColourTemperature = command.ColorTemperature;
                 return;
             }
-            else if (command.Hue != null && command.Saturation != null)
-            {
-                this.ExpectedLight.Colour.Mode = ColourMode.Other;
-                this.ExpectedLight.Colour.Hue = command.Hue;
-                this.ExpectedLight.Colour.Saturation = command.Saturation;
-            }
-            this.ExpectedLight.Colour.Mode = ColourMode.None;
-            throw new InvalidOperationException();
+            // HS or unknown: ClearColourState already set Mode = None; nothing further needed
         }
 
         public void ExecuteCommand(LightCommand command, DateTime currentTime, TransitionType transitionType)

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -72,6 +72,8 @@ namespace HueShift2.Control
             foreach (var discoveredLight in discoveredLights)
             {
                 var id = discoveredLight.Id;
+                if (discoveredLight.State.ColorMode == "hs")
+                    logger.LogWarning("[Refresh] Light {Id} ({Name}) reports HS colour mode — not supported, treating as None.", id, discoveredLight.Name);
                 if (!lights.ContainsKey(id))
                 {
                     var light = new LightControlPair(discoveredLight);

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -72,8 +72,6 @@ namespace HueShift2.Control
             foreach (var discoveredLight in discoveredLights)
             {
                 var id = discoveredLight.Id;
-                if (discoveredLight.State.ColorMode == "hs")
-                    logger.LogWarning("[Refresh] Light {Id} ({Name}) reports HS colour mode — not supported, treating as None.", id, discoveredLight.Name);
                 if (!lights.ContainsKey(id))
                 {
                     var light = new LightControlPair(discoveredLight);

--- a/HueShift2/HueShift2/Helpers/ExtensionMethods.cs
+++ b/HueShift2/HueShift2/Helpers/ExtensionMethods.cs
@@ -98,7 +98,7 @@ namespace HueShift2.Helpers
                     Brightness = expectedLight.Brightness,
                     ColorTemperature = expectedLight.Colour.ColourTemperature,
                 },
-                _ => throw new NotImplementedException(),
+                _ => new LightCommand { Brightness = expectedLight.Brightness },
             };
         }
 

--- a/HueShift2/HueShift2/Helpers/ExtensionMethods.cs
+++ b/HueShift2/HueShift2/Helpers/ExtensionMethods.cs
@@ -80,8 +80,7 @@ namespace HueShift2.Helpers
             {
                 "xy" => ColourMode.XY,
                 "ct" => ColourMode.CT,
-                "hs" => ColourMode.HS,
-                _ => throw new NotSupportedException(),
+                _ => ColourMode.None,
             };
         }
 

--- a/HueShift2/HueShift2/Host/LightScheduleWorker.cs
+++ b/HueShift2/HueShift2/Host/LightScheduleWorker.cs
@@ -33,13 +33,17 @@ namespace HueShift2.Host
 
         private ILightScheduler ResolveScheduler()
         {
-            var controller = lightSchedulers.First(x => x.Mode() == appOptionsDelegate.CurrentValue.Mode);
-            return controller;
+            return lightSchedulers.FirstOrDefault(x => x.Mode() == appOptionsDelegate.CurrentValue.Mode);
         }
 
         public async Task RunAsync()
         {
             var scheduler = ResolveScheduler();
+            if (scheduler == null)
+            {
+                logger.LogError("No scheduler registered for mode '{Mode}'. Check HueShiftOptions.Mode in config.", appOptionsDelegate.CurrentValue.Mode);
+                return;
+            }
             (bool transitionOccurred, DateTime? currentTime) = await scheduler.Execute(lastRunTime, lastTransitionTime);
             lastRunTime = currentTime;
             if (transitionOccurred) lastTransitionTime = currentTime;


### PR DESCRIPTION
## Summary

- **P1-1**: Fix wrong logger generic in `AdaptiveLightColourCalculator` — logs now appear under the correct category, not `LightManager`
- **P1-2**: Fix `CalculateSunPosition` throwing at exact Sunrise/Sunset — returns `0.0` at boundaries, `1.0` at exact Solar Noon, `-1.0` at midnight
- **P1-3**: Fix `LightScheduleWorker` failing silently on unrecognised mode — `.First` → `.FirstOrDefault` with descriptive `LogError` and graceful return
- **P1-4**: Fix `ColourMode.Other`/HS mode crashing on refresh — `"hs"` and unknown modes map to `ColourMode.None`, `ChangeColour` throw removed, `ToCommand` returns brightness-only fallback for unsupported modes

## Test plan

- [ ] Verify log entries from colour calculation appear under `HueShift2.Control.AdaptiveLightColourCalculator`, not `LightManager`
- [ ] Confirm no exception when polling fires at exact Sunrise, Sunset, Solar Noon, or midnight
- [ ] Set `HueShiftOptions.Mode` to an invalid value and confirm `LogError` appears with no crash on each tick
- [ ] Confirm a light reporting HS colour mode is refreshed and synced without `NotImplementedException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)