### PR TITLE
fix: keep lights Syncing through a grace period to stop false Manual detection

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,3 +3,6 @@ set -e
 echo "[pre-push] Checking formatting..."
 dotnet format HueShift2/HueShift2.sln --verify-no-changes -v q
 echo "[pre-push] Format check passed."
+echo "[pre-push] Running tests..."
+dotnet test HueShift2/HueShift2.sln -v q
+echo "[pre-push] Tests passed."

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0.301-resolute-arm64v8 AS build-env
 WORKDIR /app
 COPY HueShift2/*.sln ./
 COPY HueShift2/HueShift2/*.csproj ./HueShift2/
+COPY HueShift2/HueShift2.Tests/*.csproj ./HueShift2.Tests/
 RUN dotnet restore
 COPY HueShift2 ./
 RUN dotnet build

--- a/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
+++ b/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
@@ -120,6 +120,7 @@ namespace HueShift2.Tests.Control
             // Still mid-grace, bridge unconfirmed, then the light is switched off.
             pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
             pair.Refresh(BridgeState(454, on: false), syncIssuedAt.AddSeconds(4), Coolest, Warmest, SyncGracePeriod);
+            Assert.False(pair.SyncRequired);
 
             // Powers back on and a new sync is issued, 11s after the *original* sync — which
             // would already be outside the old 10s grace window if it weren't reset. The bridge
@@ -152,6 +153,48 @@ namespace HueShift2.Tests.Control
             Assert.False(pair.SyncRequired);
             Assert.False(pair.SyncConfirmed);
             Assert.True(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void GraceExpiresAfterRetryWasPending_RetryClearedAndSyncFailed()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // First poll: transition expired, bridge unconfirmed, within grace → SyncRequired = true.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
+            Assert.True(pair.SyncRequired);
+
+            // Second poll: grace period has now elapsed, bridge still unconfirmed → sync failed.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(11), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.Manual, pair.AppControlState);
+            Assert.True(pair.SyncFailed);
+            Assert.False(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+        }
+
+        [Fact]
+        public void BridgeConfirmsSyncAfterRetryWasPending_RetryClearedAndSyncConfirmed()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // First poll: transition expired, bridge unconfirmed, within grace → SyncRequired = true.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
+            Assert.True(pair.SyncRequired);
+
+            // Second poll: bridge now reports the commanded CT → sync confirmed.
+            pair.Refresh(BridgeState(339), syncIssuedAt.AddSeconds(4), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.HueShift, pair.AppControlState);
+            Assert.True(pair.SyncConfirmed);
+            Assert.False(pair.SyncRequired);
+            Assert.False(pair.SyncFailed);
         }
 
         [Fact]

--- a/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
+++ b/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
@@ -1,0 +1,173 @@
+using HueShift2.Control;
+using HueShift2.Model;
+using Q42.HueApi;
+using System;
+using Xunit;
+
+namespace HueShift2.Tests.Control
+{
+    public class LightControlPairSyncGraceTests
+    {
+        private static readonly TimeSpan SyncDuration = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan SyncGracePeriod = TimeSpan.FromSeconds(10);
+        private const int Coolest = 250;
+        private const int Warmest = 454;
+
+        private static LightControlPair CreateLightOn(int colourTemperature = 339, byte brightness = 254)
+        {
+            var networkLight = new Light
+            {
+                Id = "1",
+                Name = "Test Light",
+                State = new State
+                {
+                    On = true,
+                    Brightness = brightness,
+                    ColorMode = "ct",
+                    ColorTemperature = colourTemperature,
+                    IsReachable = true,
+                },
+            };
+            return new LightControlPair(networkLight);
+        }
+
+        private static State BridgeState(int colourTemperature, byte brightness = 254, bool on = true)
+        {
+            return new State
+            {
+                On = on,
+                Brightness = brightness,
+                ColorMode = "ct",
+                ColorTemperature = colourTemperature,
+                IsReachable = true,
+            };
+        }
+
+        [Fact]
+        public void BridgeConfirmsSyncWithinGracePeriod_PromotesToOnAndReportsConfirmed()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            pair.Refresh(BridgeState(339), syncIssuedAt.AddSeconds(1), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.HueShift, pair.AppControlState);
+            Assert.True(pair.SyncConfirmed);
+            Assert.False(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void BridgeNotYetConfirmedAndStillWithinGracePeriod_StaysSyncingAndRequestsRetry()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // Bridge reports a stale CT outside the ±50 mired match window; the 2s sync
+            // transition timer has expired, but we're still well within the 10s grace period.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.Syncing, pair.PowerState);
+            Assert.Equal(LightControlState.HueShift, pair.AppControlState);
+            Assert.True(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+            Assert.False(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void BridgeStillNotConfirmedAfterGracePeriodElapses_ShiftsToManualAndReportsFailed()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // 11s after the sync was first issued: past the 10s grace period, and the bridge
+            // still reports a CT that is not within ±50 mired of the commanded 339.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(11), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.Manual, pair.AppControlState);
+            Assert.False(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+            Assert.True(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void UserChangesStableLightDirectly_ShiftsToManualWithoutAffectingSyncOutcome()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var now = DateTime.UtcNow;
+
+            // Light is already stable On (no sync in progress) when the user changes it directly.
+            pair.Refresh(BridgeState(339), now, Coolest, Warmest, SyncGracePeriod);
+            pair.Refresh(BridgeState(454), now.AddSeconds(5), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.Manual, pair.AppControlState);
+            Assert.False(pair.SyncConfirmed);
+            Assert.False(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void LightTurnsOffMidGracePeriod_ThenBackOn_GetsAFreshFullGracePeriod()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // Still mid-grace, bridge unconfirmed, then the light is switched off.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
+            pair.Refresh(BridgeState(454, on: false), syncIssuedAt.AddSeconds(4), Coolest, Warmest, SyncGracePeriod);
+
+            // Powers back on and a new sync is issued, 11s after the *original* sync — which
+            // would already be outside the old 10s grace window if it weren't reset. The bridge
+            // still hasn't confirmed and the 2s sync transition has expired, but only 9s have
+            // elapsed since the *new* sync was issued, so this must be a retry, not a failure.
+            var secondSyncIssuedAt = syncIssuedAt.AddSeconds(11);
+            pair.ExecuteSync(SyncDuration, secondSyncIssuedAt);
+            pair.Refresh(BridgeState(454, on: true), secondSyncIssuedAt.AddSeconds(9), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.Syncing, pair.PowerState);
+            Assert.Equal(LightControlState.HueShift, pair.AppControlState);
+            Assert.True(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+            Assert.False(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void ZeroGracePeriodConfigured_FailsImmediatelyOnFirstUnconfirmedCheck()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // Sync transition timer has just expired; with a 0s grace period there is no
+            // retry window at all, so this must fail on the very first unconfirmed check.
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(2), Coolest, Warmest, TimeSpan.Zero);
+
+            Assert.Equal(LightPowerState.On, pair.PowerState);
+            Assert.Equal(LightControlState.Manual, pair.AppControlState);
+            Assert.False(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+            Assert.True(pair.SyncFailed);
+        }
+
+        [Fact]
+        public void WhileRetryingMidGrace_RequiresRetrySyncYieldsCommandAndClearsFlag()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+            pair.Refresh(BridgeState(454), syncIssuedAt.AddSeconds(3), Coolest, Warmest, SyncGracePeriod);
+
+            var requiresRetry = pair.RequiresRetrySync(out var retryCommand);
+
+            Assert.True(requiresRetry);
+            Assert.NotNull(retryCommand);
+            Assert.Equal(339, retryCommand!.ColorTemperature);
+            Assert.False(pair.RequiresRetrySync(out _));
+        }
+    }
+}

--- a/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
+++ b/HueShift2/HueShift2.Tests/Control/LightControlPairSyncGraceTests.cs
@@ -156,6 +156,24 @@ namespace HueShift2.Tests.Control
         }
 
         [Fact]
+        public void BridgeUnconfirmedAtExactGraceBoundary_StillSyncingAndRequestsRetry()
+        {
+            var pair = CreateLightOn(colourTemperature: 339);
+            var syncIssuedAt = DateTime.UtcNow;
+            pair.ExecuteSync(SyncDuration, syncIssuedAt);
+
+            // Exactly at syncIssuedAt + SyncGracePeriod: the boundary must be inclusive,
+            // so this must be a retry rather than a failure.
+            pair.Refresh(BridgeState(454), syncIssuedAt.Add(SyncGracePeriod), Coolest, Warmest, SyncGracePeriod);
+
+            Assert.Equal(LightPowerState.Syncing, pair.PowerState);
+            Assert.Equal(LightControlState.HueShift, pair.AppControlState);
+            Assert.True(pair.SyncRequired);
+            Assert.False(pair.SyncConfirmed);
+            Assert.False(pair.SyncFailed);
+        }
+
+        [Fact]
         public void GraceExpiresAfterRetryWasPending_RetryClearedAndSyncFailed()
         {
             var pair = CreateLightOn(colourTemperature: 339);

--- a/HueShift2/HueShift2.Tests/HueShift2.Tests.csproj
+++ b/HueShift2/HueShift2.Tests/HueShift2.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HueShift2\HueShift2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HueShift2/HueShift2.sln
+++ b/HueShift2/HueShift2.sln
@@ -12,16 +12,42 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HueShift2.Tests", "HueShift2.Tests\HueShift2.Tests.csproj", "{FA620B47-D9A4-4899-8243-F4035128C73C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|x64.Build.0 = Release|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{A86ECF64-E009-4DA2-9B78-B5B7CCD526B2}.Release|x86.Build.0 = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|x64.Build.0 = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA620B47-D9A4-4899-8243-F4035128C73C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HueShift2/HueShift2.sln
+++ b/HueShift2/HueShift2.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HueShift2.Tests", "HueShift2.Tests\HueShift2.Tests.csproj", "{FA620B47-D9A4-4899-8243-F4035128C73C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HueShift2.Tests", "HueShift2.Tests\HueShift2.Tests.csproj", "{FA620B47-D9A4-4899-8243-F4035128C73C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HueShift2/HueShift2/Configuration/Model/HueShiftOptions.cs
+++ b/HueShift2/HueShift2/Configuration/Model/HueShiftOptions.cs
@@ -14,6 +14,7 @@ namespace HueShift2.Configuration.Model
         public int PollingFrequency { get; set; }
         public int TransitionInterval { get; set; }
         public int BasicTransitionDuration { get; set; }
+        public int SyncGracePeriod { get; set; } = 10;
         public int AdaptiveTransitionDuration { get; set; }
         public int SolarTransitionDuration { get; set; }
         public SolarTransitionTimeLimits SolarTransitionTimeLimits { get; set; }
@@ -33,6 +34,7 @@ namespace HueShift2.Configuration.Model
         {
             Mode = HueShiftMode.Adaptive;
             BasicTransitionDuration = 2;
+            SyncGracePeriod = 10;
             AdaptiveTransitionDuration = 30;
             SolarTransitionDuration = 120;
             SolarTransitionTimeLimits = new SolarTransitionTimeLimits

--- a/HueShift2/HueShift2/Control/LightControlPair.cs
+++ b/HueShift2/HueShift2/Control/LightControlPair.cs
@@ -59,6 +59,7 @@ namespace HueShift2.Control
                 this.PowerState = LightPowerState.Off;
                 this.Transition = null;
                 this.syncIssuedAt = null;
+                this.SyncRequired = false;
             }
         }
 
@@ -82,6 +83,7 @@ namespace HueShift2.Control
                                 this.PowerState = LightPowerState.On;
                                 this.Transition = null;
                                 this.syncIssuedAt = null;
+                                this.SyncRequired = false;
                                 this.SyncConfirmed = true;
                             }
                             else if (this.Transition.IsExpired(currentTime))
@@ -96,6 +98,7 @@ namespace HueShift2.Control
                                     this.PowerState = LightPowerState.On;
                                     this.Transition = null;
                                     this.syncIssuedAt = null;
+                                    this.SyncRequired = false;
                                     this.AppControlState = LightControlState.Manual;
                                     this.SyncFailed = true;
                                 }

--- a/HueShift2/HueShift2/Control/LightControlPair.cs
+++ b/HueShift2/HueShift2/Control/LightControlPair.cs
@@ -88,7 +88,7 @@ namespace HueShift2.Control
                             }
                             else if (this.Transition.IsExpired(currentTime))
                             {
-                                var withinGrace = this.syncIssuedAt.HasValue && (currentTime - this.syncIssuedAt.Value) < syncGracePeriod;
+                                var withinGrace = this.syncIssuedAt.HasValue && (currentTime - this.syncIssuedAt.Value) <= syncGracePeriod;
                                 if (withinGrace)
                                 {
                                     this.SyncRequired = true;

--- a/HueShift2/HueShift2/Control/LightControlPair.cs
+++ b/HueShift2/HueShift2/Control/LightControlPair.cs
@@ -20,6 +20,10 @@ namespace HueShift2.Control
         public Transition Transition { get; private set; }
         public bool ResetOccurred { get; private set; }
         public bool SyncRequired { get; private set; }
+        public bool SyncConfirmed { get; private set; }
+        public bool SyncFailed { get; private set; }
+
+        private DateTime? syncIssuedAt;
 
         public LightControlPair(Light networkLight)
         {
@@ -36,7 +40,7 @@ namespace HueShift2.Control
         {
             if (isOn)
             {
-                if (this.PowerState == LightPowerState.Transitioning || this.PowerState == LightPowerState.Syncing)
+                if (this.PowerState == LightPowerState.Transitioning)
                 {
                     if (this.Transition == null) throw new NullReferenceException();
                     if (this.Transition.IsExpired(currentTime))
@@ -45,7 +49,7 @@ namespace HueShift2.Control
                         this.Transition = null;
                     }
                 }
-                else
+                else if (this.PowerState != LightPowerState.Syncing)
                 {
                     this.PowerState = LightPowerState.On;
                 }
@@ -54,13 +58,16 @@ namespace HueShift2.Control
             {
                 this.PowerState = LightPowerState.Off;
                 this.Transition = null;
+                this.syncIssuedAt = null;
             }
         }
 
-        public void Refresh(State networkLight, DateTime currentTime, int minCt, int maxCt)
+        public void Refresh(State networkLight, DateTime currentTime, int minCt, int maxCt, TimeSpan syncGracePeriod)
         {
             this.NetworkLight = networkLight;
             this.ExpectedLight.Brightness = this.NetworkLight.Brightness;
+            this.SyncConfirmed = false;
+            this.SyncFailed = false;
             var isOn = networkLight.DeterminePowerState() == LightPowerState.On;
             var wasOff = this.PowerState == LightPowerState.Off;
             if (isOn)
@@ -68,13 +75,35 @@ namespace HueShift2.Control
                 switch (this.AppControlState)
                 {
                     case LightControlState.HueShift:
-                        if (!this.NetworkLight.Equals(this.ExpectedLight, minCt, maxCt) && this.PowerState == LightPowerState.On)
+                        if (this.PowerState == LightPowerState.Syncing)
+                        {
+                            if (this.NetworkLight.Equals(this.ExpectedLight, minCt, maxCt))
+                            {
+                                this.PowerState = LightPowerState.On;
+                                this.Transition = null;
+                                this.syncIssuedAt = null;
+                                this.SyncConfirmed = true;
+                            }
+                            else if (this.Transition.IsExpired(currentTime))
+                            {
+                                var withinGrace = this.syncIssuedAt.HasValue && (currentTime - this.syncIssuedAt.Value) < syncGracePeriod;
+                                if (withinGrace)
+                                {
+                                    this.SyncRequired = true;
+                                }
+                                else
+                                {
+                                    this.PowerState = LightPowerState.On;
+                                    this.Transition = null;
+                                    this.syncIssuedAt = null;
+                                    this.AppControlState = LightControlState.Manual;
+                                    this.SyncFailed = true;
+                                }
+                            }
+                        }
+                        else if (!this.NetworkLight.Equals(this.ExpectedLight, minCt, maxCt) && this.PowerState == LightPowerState.On)
                         {
                             this.AppControlState = LightControlState.Manual;
-                        }
-                        if (this.NetworkLight.Equals(this.ExpectedLight, minCt, maxCt) && this.PowerState == LightPowerState.Syncing)
-                        {
-                            this.PowerState = LightPowerState.On;
                         }
                         break;
                     case LightControlState.Manual:
@@ -125,6 +154,16 @@ namespace HueShift2.Control
             }
 
             return false;
+        }
+
+        public bool RequiresRetrySync(out LightCommand syncCommand)
+        {
+            syncCommand = null;
+            if (this.PowerState != LightPowerState.Syncing || !this.SyncRequired)
+                return false;
+            this.SyncRequired = false;
+            syncCommand = this.ExpectedLight.ToCommand();
+            return true;
         }
 
         public void Reset()
@@ -196,6 +235,7 @@ namespace HueShift2.Control
         {
             this.PowerState = LightPowerState.Syncing;
             this.Transition = new Transition(currentTime, duration, TransitionType.Sync);
+            this.syncIssuedAt ??= currentTime;
         }
 
         public override string ToString()

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -44,7 +44,7 @@ namespace HueShift2.Control
             return discoveredLights;
         }
 
-        private async Task Synchronise(IDictionary<string, LightCommand> syncCommandsPairs, DateTime currentTime)
+        private async Task Synchronise(IDictionary<string, LightCommand> syncCommandsPairs, DateTime currentTime, bool logSync = true)
         {
             var duration = TimeSpan.FromSeconds(appOptionsDelegate.CurrentValue.BasicTransitionDuration);
             var lightNames = syncCommandsPairs.Keys.Select(id => lights[id].Properties.Name);
@@ -58,7 +58,7 @@ namespace HueShift2.Control
                 light.ExecuteSync(duration, currentTime);
                 await client.SendCommandAsync(syncCommand, new[] { id });
             }
-            logger.LogSync(lightNames, lights[syncCommandsPairs.Keys.First()].ExpectedLight);
+            if (logSync) logger.LogSync(lightNames, lights[syncCommandsPairs.Keys.First()].ExpectedLight);
         }
 
         public async Task Refresh(DateTime currentTime)
@@ -68,6 +68,7 @@ namespace HueShift2.Control
             var ct = appOptionsDelegate.CurrentValue.ColourTemperature;
 
             var syncCommands = new Dictionary<string, LightCommand>();
+            var retrySyncCommands = new Dictionary<string, LightCommand>();
             var refreshLog = new List<(CachedControlPair stale, LightControlPair current)>();
             foreach (var discoveredLight in discoveredLights)
             {
@@ -87,17 +88,28 @@ namespace HueShift2.Control
                 {
                     var light = lights[id];
                     var staleLight = new CachedControlPair(light);
-                    light.Refresh(discoveredLight.State, currentTime, ct.Coolest, ct.Warmest);
+                    var syncGracePeriod = TimeSpan.FromSeconds(appOptionsDelegate.CurrentValue.SyncGracePeriod);
+                    light.Refresh(discoveredLight.State, currentTime, ct.Coolest, ct.Warmest, syncGracePeriod);
                     refreshLog.Add((staleLight, light));
-                    if (light.PowerState != LightPowerState.Syncing && light.PowerState != LightPowerState.Transitioning)
+                    if (light.RequiresRetrySync(out LightCommand retrySyncCommand))
+                    {
+                        retrySyncCommands.Add(id, retrySyncCommand);
+                    }
+                    else if (light.PowerState != LightPowerState.Syncing && light.PowerState != LightPowerState.Transitioning)
                     {
                         if (light.RequiresSync(out LightCommand syncCommand))
                             syncCommands.Add(id, syncCommand);
                     }
                 }
             }
-            logger.LogRefresh(refreshLog);
+            var syncConfirmedPairs = refreshLog.Where(p => p.current.SyncConfirmed).ToList();
+            var syncFailedPairs = refreshLog.Where(p => p.current.SyncFailed).ToList();
+            var regularRefreshLog = refreshLog.Except(syncConfirmedPairs).Except(syncFailedPairs);
+            logger.LogRefresh(regularRefreshLog);
+            logger.LogSyncConfirmed(syncConfirmedPairs);
+            logger.LogSyncFailed(syncFailedPairs);
             if (syncCommands.Any()) await Synchronise(syncCommands, currentTime);
+            if (retrySyncCommands.Any()) await Synchronise(retrySyncCommands, currentTime, logSync: false);
             foreach (var idLightPair in lights)
             {
                 if (idLightPair.Key != idLightPair.Value.Properties.Id)

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -104,7 +104,7 @@ namespace HueShift2.Control
             }
             var syncConfirmedPairs = refreshLog.Where(p => p.current.SyncConfirmed).ToList();
             var syncFailedPairs = refreshLog.Where(p => p.current.SyncFailed).ToList();
-            var regularRefreshLog = refreshLog.Except(syncConfirmedPairs).Except(syncFailedPairs);
+            var regularRefreshLog = refreshLog.Where(p => !p.current.SyncConfirmed && !p.current.SyncFailed);
             logger.LogRefresh(regularRefreshLog);
             logger.LogSyncConfirmed(syncConfirmedPairs);
             logger.LogSyncFailed(syncFailedPairs);

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -70,6 +70,8 @@ namespace HueShift2.Control
             var syncCommands = new Dictionary<string, LightCommand>();
             var retrySyncCommands = new Dictionary<string, LightCommand>();
             var refreshLog = new List<(CachedControlPair stale, LightControlPair current)>();
+            var options = appOptionsDelegate.CurrentValue;
+            var syncGracePeriod = TimeSpan.FromSeconds(options.SyncGracePeriod);
             foreach (var discoveredLight in discoveredLights)
             {
                 var id = discoveredLight.Id;
@@ -80,7 +82,7 @@ namespace HueShift2.Control
                     if (cachedLightCommand is not null)
                     {
                         var syncCommand = cachedLightCommand;
-                        syncCommand.TransitionTime = TimeSpan.FromSeconds(appOptionsDelegate.CurrentValue.BasicTransitionDuration);
+                        syncCommand.TransitionTime = TimeSpan.FromSeconds(options.BasicTransitionDuration);
                         syncCommands.Add(id, syncCommand);
                     }
                 }
@@ -88,7 +90,6 @@ namespace HueShift2.Control
                 {
                     var light = lights[id];
                     var staleLight = new CachedControlPair(light);
-                    var syncGracePeriod = TimeSpan.FromSeconds(appOptionsDelegate.CurrentValue.SyncGracePeriod);
                     light.Refresh(discoveredLight.State, currentTime, ct.Coolest, ct.Warmest, syncGracePeriod);
                     refreshLog.Add((staleLight, light));
                     if (light.RequiresRetrySync(out LightCommand retrySyncCommand))

--- a/HueShift2/HueShift2/Control/LightManager.cs
+++ b/HueShift2/HueShift2/Control/LightManager.cs
@@ -65,13 +65,13 @@ namespace HueShift2.Control
         {
             await clientManager.AssertConnected();
             var discoveredLights = await Discover();
-            var ct = appOptionsDelegate.CurrentValue.ColourTemperature;
+            var options = appOptionsDelegate.CurrentValue;
+            var ct = options.ColourTemperature;
+            var syncGracePeriod = TimeSpan.FromSeconds(options.SyncGracePeriod);
 
             var syncCommands = new Dictionary<string, LightCommand>();
             var retrySyncCommands = new Dictionary<string, LightCommand>();
             var refreshLog = new List<(CachedControlPair stale, LightControlPair current)>();
-            var options = appOptionsDelegate.CurrentValue;
-            var syncGracePeriod = TimeSpan.FromSeconds(options.SyncGracePeriod);
             foreach (var discoveredLight in discoveredLights)
             {
                 var id = discoveredLight.Id;

--- a/HueShift2/HueShift2/Logging/ExtensionMethods.cs
+++ b/HueShift2/HueShift2/Logging/ExtensionMethods.cs
@@ -107,6 +107,38 @@ namespace HueShift2.Logging
             }
         }
 
+        public static void LogSyncConfirmed<T>(this ILogger<T> logger, IEnumerable<(CachedControlPair stale, LightControlPair current)> pairs)
+        {
+            var entries = pairs.ToList();
+            if (!entries.Any()) return;
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                foreach (var p in entries)
+                {
+                    logger.LogDebug(p.stale.ToString());
+                    logger.LogDebug(p.current.ToString());
+                }
+            }
+            var names = string.Join(", ", entries.Select(p => p.current.Properties.Name));
+            logger.LogInformation($"[Sync] confirmed | {entries.Count} light(s) | {names}");
+        }
+
+        public static void LogSyncFailed<T>(this ILogger<T> logger, IEnumerable<(CachedControlPair stale, LightControlPair current)> pairs)
+        {
+            var entries = pairs.ToList();
+            if (!entries.Any()) return;
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                foreach (var p in entries)
+                {
+                    logger.LogDebug(p.stale.ToString());
+                    logger.LogDebug(p.current.ToString());
+                }
+            }
+            var names = string.Join(", ", entries.Select(p => p.current.Properties.Name));
+            logger.LogWarning($"[Sync] failed → Manual | {entries.Count} light(s) | {names}");
+        }
+
         public static void LogUpdate<T>(this ILogger<T> logger, IEnumerable<LightControlPair> lights)
         {
             logger.LogDebug("New light states in memory:");


### PR DESCRIPTION
## Summary
- Kitchen Ceiling and Cooker Ceiling bulbs were being falsely flagged as Manual Override seconds after a power-on Sync, because the Hue bridge sometimes lags more than 2s to report the commanded colour temperature.
- `LightControlPair` now keeps a light in `Syncing` for a configurable `SyncGracePeriod` (10s default), silently retrying the sync command on each poll until the bridge confirms (`SyncConfirmed`) or the grace period elapses (`SyncFailed` → `Manual`).
- `LightManager` issues retries without the noisy repeated `[Sync]` log line; confirmed/failed outcomes get their own `[Sync] confirmed` / `[Sync] failed → Manual` log lines.
- Added a `HueShift2.Tests` xUnit project covering the 6 BDD scenarios agreed for this fix (fast confirm, retry in grace, grace expired, genuine manual override, light off mid-grace resets the window, zero grace period fails immediately) plus the retry-command helper.
- `.githooks/pre-push` now runs `dotnet test` after the format check.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 7/7 passing
- [ ] Deploy to Pi and confirm Kitchen/Cooker ceiling bulbs no longer false-flip to Manual on power-on

🤖 Generated with Claude Code